### PR TITLE
fix: 🐛 error in React 17

### DIFF
--- a/examples/animate.tsx
+++ b/examples/animate.tsx
@@ -58,7 +58,7 @@ const MyItem: React.ForwardRefRenderFunction<any, MyItemProps> = (
   ref,
 ) => {
   const motionRef = React.useRef(false);
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     return () => {
       if (motionRef.current) {
         onAppear();

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -248,7 +248,7 @@ export function RawList<T>(props: ListProps<T>, ref: React.Ref<ListRef>) {
     return true;
   });
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     // Firefox only
     function onMozMousePixelScroll(e: Event) {
       if (inVirtual) {

--- a/src/hooks/useMobileTouchMove.ts
+++ b/src/hooks/useMobileTouchMove.ts
@@ -66,7 +66,7 @@ export default function useMobileTouchMove(
     }
   };
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (inVirtual) {
       listRef.current.addEventListener('touchstart', onTouchStart);
     }


### PR DESCRIPTION
thanks @jueinin

I wasn't entirely sure if we should use useLayoutEffect here, or just declare a variable for `listRef.current` outside the return function as described here: https://reactjs.org/blog/2020/08/10/react-v17-rc.html#potential-issues
